### PR TITLE
Add brem test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,12 @@ include ( ${Geant4_USE_FILE} )
 #-------------------------------------------------------------------------------
 # Set the CXX flags and default build type
 #
-#if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
-#  if (NOT CMAKE_BUILD_TYPE)
-#    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
-#  endif()
-#endif()
-#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
+  if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+  endif()
+endif()
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,3 +68,7 @@ target_link_libraries (dpm_GenerateData  ${Geant4_LIBRARIES})
 
 add_executable ( dpm_Simulate ${CMAKE_SOURCE_DIR}/dpm_Simulate.cc ${cxx_sources_SIM})
 target_link_libraries (dpm_Simulate)
+
+## add model level test for bremsstrahlung
+add_executable ( test_brem ${CMAKE_SOURCE_DIR}/test_brem.cc ${cxx_sources_SIM})
+target_link_libraries (test_brem)

--- a/Configuration.hh
+++ b/Configuration.hh
@@ -94,7 +94,9 @@ public:
               fTheG4MaterialNames[2] = "G4_BONE_COMPACT_ICRU";
               break;
       // indx = 4 : homogeneous Titatnium with all default but the material list
-      case 4: fTheG4MaterialNames.resize(1);
+      case 4: fMscStepSlow  = 2.0; // [mm]
+              fMscStepShigh = 5.0; // [mm]
+              fTheG4MaterialNames.resize(1);
               fTheG4MaterialNames[0] = "G4_Ti";
               break;
       // indx = 5 : homogeneous Tungsten with all default but the material list

--- a/Simulation/inc/SimDPMLike.hh
+++ b/Simulation/inc/SimDPMLike.hh
@@ -24,6 +24,7 @@ class SimPhotonData;
 
 class SimSBTables;
 class SimMollerTables;
+class SimGSTables;
 
 class Track;
 
@@ -78,6 +79,13 @@ void   RotateToLabFrame(double* dir, double* refdir);
 void   PerformBrem(Track& track, SimSBTables* theSBTable);
 // Auxiliary funtion for ionisation (Moller) final state generation.
 void   PerformMoller(Track& track, SimMollerTables* theMollerTable);
+// Auxiliary funtion to perform angular delfection due to MSC.
+// NOTE: that angular deflection is applied beween the pre- and post-step point
+//       while it needs to be computed at the e- energy at the pre-step point.
+//       The pre-step point kinetic energy is `ekin0` while the current kinetic
+//       energy is `track.fEkin`.
+void PerformMSCAngularDeflection(Track& track, double ekin0, SimGSTables* theGSTables);
+
 
 // Auxiliary funtion for simple e+e- annihilation
 void   PerformAnnihilation(Track& track);

--- a/Simulation/inc/SimDPMLike.hh
+++ b/Simulation/inc/SimDPMLike.hh
@@ -22,6 +22,8 @@ class SimMaterialData;
 class SimElectronData;
 class SimPhotonData;
 
+class SimSBTables;
+
 class Track;
 
 //
@@ -70,6 +72,10 @@ void   KeepTrackingPhoton(SimPhotonData& phData, SimMaterialData& matData, Geom&
 // computed.
 void   RotateToLabFrame(double &u, double &v, double &w, double u1, double u2, double u3);
 void   RotateToLabFrame(double* dir, double* refdir);
+
+// Auxiliary funtion for bremsstrahlung final state generation.
+//
+void   PerformBrem(Track& track, SimSBTables* theSBTable);
 
 // Auxiliary funtion for simple e+e- annihilation
 void   PerformAnnihilation(Track& track);

--- a/Simulation/inc/SimDPMLike.hh
+++ b/Simulation/inc/SimDPMLike.hh
@@ -23,6 +23,7 @@ class SimElectronData;
 class SimPhotonData;
 
 class SimSBTables;
+class SimMollerTables;
 
 class Track;
 
@@ -74,8 +75,9 @@ void   RotateToLabFrame(double &u, double &v, double &w, double u1, double u2, d
 void   RotateToLabFrame(double* dir, double* refdir);
 
 // Auxiliary funtion for bremsstrahlung final state generation.
-//
 void   PerformBrem(Track& track, SimSBTables* theSBTable);
+// Auxiliary funtion for ionisation (Moller) final state generation.
+void   PerformMoller(Track& track, SimMollerTables* theMollerTable);
 
 // Auxiliary funtion for simple e+e- annihilation
 void   PerformAnnihilation(Track& track);

--- a/dpm_Simulate.cc
+++ b/dpm_Simulate.cc
@@ -33,7 +33,7 @@ static int           gConfigIndex       =  0;       // 0 that corresponds to a h
 //
 static struct option options[] = {
   {"primary-particle    (possible particle names: e-, gamma)            - default: e-"     , required_argument, 0, 'p'},
-  {"primary-energy      (in [MeV] units)                                - default: 0.1"    , required_argument, 0, 'e'},
+  {"primary-energy      (in [MeV] units)                                - default: 15"     , required_argument, 0, 'e'},
   {"number-of-histories (number of primary events to simulate)          - default: 1.0E+5" , required_argument, 0, 'n'},
   {"input-data-dir      (where the pre-generated data are located)      - default: ./data" , required_argument, 0, 'd'},
   {"voxel-size          (size of the voxel/box in [mm])                 - default: 1.0"    , required_argument, 0, 'b'},
@@ -41,7 +41,7 @@ static struct option options[] = {
   {"help"                                                                                  , no_argument      , 0, 'h'},
   {0, 0, 0, 0}
 };
-// auxiliary functions fot obtaining input arguments
+// auxiliary functions for obtaining input arguments
 void Help();
 void GetOpt(int argc, char *argv[]);
 

--- a/test_brem.cc
+++ b/test_brem.cc
@@ -1,0 +1,173 @@
+//
+// == M. Novak: 2021
+//
+// This model-level test can be used to test the rejection-free sampling of the
+// energy distribution, transferred to the emitted photon in case of e-
+// bremsstrahlung, according to the Seltzer-Berger DCS.
+//
+// NOTE: `dpm_GenerateData` needs to be executed before since this test rely on
+//       the generated data. Furthermore, exatly the same function ( the
+//       `SimDPMLike::PerformBrem()`) that is used during teh simualtion, is
+//       used by the test to generate samples according to the DCS determined
+//       by the primary e- primary energy and the material. The materials, as
+//       well as the secondary gamma productio threshold, are those used during
+//       the data generation and can be selected by their index(that corresponds
+//       to their order of definition).
+//
+// NOTE: if the matrial index is valid or the primary energy is indeed higher
+//       than the gamma cut, ect. are not tested (since developers should be
+//       well aware of these constraints of a restricted brem. description).
+
+
+#include "SimDPMLike.hh"
+#include "SimSBTables.hh"
+#include "SimMaterialData.hh"
+#include "Random.hh"
+#include "Track.hh"
+#include "TrackStack.hh"
+
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <vector>
+#include <cstdio>
+
+#include <getopt.h>
+
+static std::string   gInputDataDir("./data");       // location of the pre-generated data
+static double        gPrimaryEnergy     =  12.345;  // primary particle energy in [MeV] (> gamma-cut)
+static int           gNumPrimaries      =  1.0E+5;  // generate 100 000 samples from the brem. interaction
+static int           gMaterialIndex     =       0;  // material index (one of those data generated for)
+//
+static struct option options[] = {
+  {"primary-energy      (in [MeV] units)                                - default: 12.345" , required_argument, 0, 'e'},
+  {"number-of-primaries (number of interactions to sample)              - default: 1.0E+5" , required_argument, 0, 'n'},
+  {"input-data-dir      (where the pre-generated data are located)      - default: ./data" , required_argument, 0, 'd'},
+  {"material-index      (one of the material index data generated for)  - default: 0"      , required_argument, 0, 'm'},
+  {"help"                                                                                  , no_argument      , 0, 'h'},
+  {0, 0, 0, 0}
+};
+// auxiliary functions for obtaining input arguments
+void Help();
+void GetOpt(int argc, char *argv[]);
+
+
+int main(int argc, char *argv[]) {
+  //
+  // get the input arguments
+  GetOpt(argc, argv);
+  //
+  // Load Material data
+  SimMaterialData theSimMaterialData;
+  theSimMaterialData.Load(gInputDataDir);
+  // Load SB sampling tables
+  SimSBTables theSBTables;
+  theSBTables.LoadData(gInputDataDir, 1);
+  //
+  const double gammaCut = theSimMaterialData.fGammaCut;
+  //
+  // create a histogram of the x =  log10(k/E_0)
+  int    hbins = 101;
+  double  xmin = std::log10(gammaCut/gPrimaryEnergy);
+  double  xmax = 0.1;
+  double  hdel = (xmax-xmin)/(hbins-1);
+  double ihdel = 1./hdel;
+  std::vector<double> theHist(hbins, 0.);
+  // create a primary and secondary track
+  Track  primaryTrack;
+  Track  secondaryTrack;
+  for (int is=0; is<gNumPrimaries; ++is) {
+    // set initial properties of the primary electron (that are updated in the
+    // interaction) according to the input arguments
+    // NOTE: material indes do not changed but keep them together for clarity
+    primaryTrack.fEkin         = gPrimaryEnergy;
+    primaryTrack.fMatIndx      = gMaterialIndex;
+    primaryTrack.fDirection[0] = 0.;
+    primaryTrack.fDirection[1] = 0.;
+    primaryTrack.fDirection[2] = 1.;
+    //
+    // use the fuction from SimDPMLike to perform the brem intercation
+    PerformBrem(primaryTrack, &theSBTables);
+    // NOTE: in each interactions, secondary tracks are pushed to the global
+    //       TrackStack so get the secondary track
+    TrackStack::Instance().PopIntoThisTrack(secondaryTrack);
+    // get the secondary (emitted photon) energy
+    const double theK  =  secondaryTrack.fEkin;
+    // compute the reduced photon energy k/E_0
+    double redPhEnergy = theK/gPrimaryEnergy;
+    if (redPhEnergy>0.0) {
+      redPhEnergy = std::log10(redPhEnergy);
+      theHist[(int)((redPhEnergy-xmin)*ihdel)] += 1.0;
+    }
+  }
+  // normalisation
+  double norm = 0.0;
+  for (int ih=0; ih<hbins-1; ++ih) {
+    norm += 0.5*hdel*(theHist[ih]+theHist[ih+1]);
+  }
+  norm = 1./norm;
+  FILE* f = fopen("res_brem_test_ph_energy.dat","w");
+  for (int ih=0; ih<hbins-1; ++ih) {
+    fprintf(f, "%d %lg %lg\n", ih, xmin+(ih+0.5)*hdel, theHist[ih]*norm);
+  }
+  fclose(f);
+
+ return 0;
+}
+
+
+//
+// Inplementation of the auxiliary functions for obtaining input ragumets
+//
+void Help() {
+  std::cout<<"\n "<<std::setw(120)<<std::setfill('=')<<""<<std::setfill(' ')<<std::endl;
+  std::cout<<"  A bremsstrahlung interaction test."
+           << std::endl;
+  std::cout<<"\n  Usage: test_brem [OPTIONS] \n"<<std::endl;
+  for (int i = 0; options[i].name != NULL; i++) {
+    printf("\t-%c  --%s\n", options[i].val, options[i].name);
+  }
+  std::cout<<"\n "<<std::setw(120)<<std::setfill('=')<<""<<std::setfill(' ')<<std::endl;
+}
+
+
+void GetOpt(int argc, char *argv[]) {
+  while (true) {
+    int c, optidx = 0;
+    c = getopt_long(argc, argv, "h:e:n:d:m:", options, &optidx);
+    if (c == -1)
+      break;
+    switch (c) {
+    case 0:
+       c = options[optidx].val;
+       /* fall through */
+    case 'e':
+       gPrimaryEnergy = std::stod(optarg);
+       break;
+    case 'n':
+       gNumPrimaries  = std::stoi(optarg);
+       break;
+    case 'd':
+       gInputDataDir  = optarg;
+       break;
+    case 'm':
+       gMaterialIndex = std::stoi(optarg);
+       break;
+    case 'h':
+       Help();
+       exit(-1);
+       break;
+    default:
+      printf(" *** Unknown input argument: %c\n",c);
+      Help();
+      exit(-1);
+    }
+   }
+   std::cout << "\n === The test_brem simulation confguration: \n"
+            << "\n     - input data directory  : " << gInputDataDir
+            << "\n     - primary energy        : " << gPrimaryEnergy << " [MeV]"
+            << "\n     - number of interaction : " << gNumPrimaries
+            << "\n     - material index        : " << gMaterialIndex
+            << std::endl;
+}


### PR DESCRIPTION
Separate the discrete electron interactions (bremsstrahlung, ionisation and MSC angular deflection) into separate functions.
Use the bremsstrahlung related function in a simple model-level test for testing the rejection-free final sated generation of discrete (super-threshold) electron bremsstrahlung event. 